### PR TITLE
Fix TypeScript build error in Close.ts: correct rights type and null handling

### DIFF
--- a/src/gateway/events/Close.ts
+++ b/src/gateway/events/Close.ts
@@ -82,19 +82,20 @@ export async function Close(this: WebSocket, code: number, reason: Buffer) {
 		// which will cause this to throw when they disconnect.
 		// just send the ID of the user instead of the full correct payload for now
 		const userOrId = await User.getPublicUser(this.user_id).catch(() => ({
-		id: this.user_id,
-	}));
+			id: this.user_id,
+		}));
 
-	let u: { id: string; rights: number } | undefined;
-	try {
-		u = await User.findOne({
-			where: { id: this.user_id },
-			select: ["id", "rights"],
-		});
-	} catch {
-		u = undefined;
-	}
-	if (!u || shouldRoutePresenceFromRights(u.rights)) {
+		let u: { id: string; rights: string } | undefined;
+		try {
+			u =
+				(await User.findOne({
+					where: { id: this.user_id },
+					select: ["id", "rights"],
+				})) ?? undefined;
+		} catch {
+			u = undefined;
+		}
+		if (!u || shouldRoutePresenceFromRights(u.rights)) {
 			await emitEvent({
 				event: "PRESENCE_UPDATE",
 				user_id: this.user_id,

--- a/src/gateway/events/Close.ts
+++ b/src/gateway/events/Close.ts
@@ -82,14 +82,19 @@ export async function Close(this: WebSocket, code: number, reason: Buffer) {
 		// which will cause this to throw when they disconnect.
 		// just send the ID of the user instead of the full correct payload for now
 		const userOrId = await User.getPublicUser(this.user_id).catch(() => ({
-			id: this.user_id,
-		}));
+		id: this.user_id,
+	}));
 
-		const u = await User.findOneOrFail({
+	let u: { id: string; rights: number } | undefined;
+	try {
+		u = await User.findOne({
 			where: { id: this.user_id },
 			select: ["id", "rights"],
-		}).catch(() => undefined);
-		if (!u || shouldRoutePresenceFromRights(u.rights)) {
+		});
+	} catch {
+		u = undefined;
+	}
+	if (!u || shouldRoutePresenceFromRights(u.rights)) {
 			await emitEvent({
 				event: "PRESENCE_UPDATE",
 				user_id: this.user_id,


### PR DESCRIPTION
## Summary
Fixed TypeScript compilation error in `src/gateway/events/Close.ts` that was causing the Nix build to fail. The fix addresses two type mismatches:

1. Changed `User.rights` type from `number` to `string` to match the actual User entity definition
2. Added `?? undefined` to convert `null` from `User.findOne()` to `undefined` for type compatibility
3. Switched from `findOneOrFail().catch()` to `findOne()` with explicit try-catch for clearer error handling

## Review & Testing Checklist for Human
- [ ] Verify that `User.rights` is indeed typed as `string` in the User entity (not `number`)
- [ ] Confirm that `shouldRoutePresenceFromRights` accepts `string` type for the rights parameter (should accept `bigint | number | string`)
- [ ] Test the edge case: delete a user account while they're connected to the gateway, then disconnect them - verify presence updates are handled correctly
- [ ] Review whether the error handling change from `findOneOrFail().catch()` to `findOne()` with try-catch is semantically equivalent

### Notes
- The build now passes locally (`pnpm build` and `pnpm lint` both succeed)
- CI checks are passing on GitHub Actions
- This fixes the deleted user edge case handling that was originally implemented in the PR

**Link to Devin run**: https://app.devin.ai/sessions/ef0c6546b5f74d9193a56a7667c44851  
**Builds upon**: Locally run Google Antigravity session
**Requested by**: Erkin Alp Güney (@erkinalp)